### PR TITLE
Add colorbrewer as dependency for pal()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,4 +13,5 @@ Depends:
     picante,
     diversitree,
     phytools,
-    dplyr
+    dplyr,
+    RColorBrewer


### PR DESCRIPTION
I believe it is correct to add it as a dependence so it is installed with aRbor.
